### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,4 +1,6 @@
 name: CI
+permissions:
+  contents: read
 on:
   push:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/grokify/gocharts/security/code-scanning/3](https://github.com/grokify/gocharts/security/code-scanning/3)

The best fix is to explicitly set the `permissions` for the workflow or the `test` job to limit the GitHub token’s access to the repository. Since the workflow's jobs only install Go, check out code, and run tests, the minimal required permission is `contents: read`. This prevents unnecessary write access and aligns with the principle of least privilege.

**How:**  
- Insert a `permissions:` block at the root level of the workflow file (`.github/workflows/ci.yaml`), preferably just after the `name` and before the `on:` key.  
- The block should read:  
  ```yaml
  permissions:
    contents: read
  ```
- Alternatively, the block can be inserted within the specific job if only that job should have limited permissions, but the root level is generally simpler and covers all jobs unless otherwise specified.
- No additional libraries, methods, or imports are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
